### PR TITLE
Speed up drift- and leapsecond related calculations

### DIFF
--- a/src/sofa.jl
+++ b/src/sofa.jl
@@ -1,21 +1,21 @@
 """
     Drift second parameters
 """
-struct Driftsecond
-    year::Integer
-    month::Integer
-    mjd::Real
-    offset::Real
-    rate::Real
+struct Driftsecond{T<:Integer, U<:Real}
+    year::T
+    month::T
+    mjd::U
+    offset::U
+    rate::U
 end
 
 """
     Leap second parameters
 """
-struct Leapsecond
-    year::Integer
-    month::Integer
-    second::Real
+struct Leapsecond{T<:Integer, U<:Real}
+    year::T
+    month::T
+    second::U
 end
 
 """
@@ -63,7 +63,7 @@ const TINY = 1e-6
 
 # Reference dates and drift rates (sec/day), pre leap seconds.
 const DRIFTSECOND =
-    [Driftsecond(1960,  1, 37300.0, 1.4178180, 0.0012960),
+    (Driftsecond(1960,  1, 37300.0, 1.4178180, 0.0012960),
      Driftsecond(1961,  1, 37300.0, 1.4228180, 0.0012960),
      Driftsecond(1961,  8, 37300.0, 1.3728180, 0.0012960),
      Driftsecond(1962,  1, 37665.0, 1.8458580, 0.0011232),
@@ -76,11 +76,11 @@ const DRIFTSECOND =
      Driftsecond(1965,  7, 38761.0, 3.7401300, 0.0012960),
      Driftsecond(1965,  9, 38761.0, 3.8401300, 0.0012960),
      Driftsecond(1966,  1, 39126.0, 4.3131700, 0.0025920),
-     Driftsecond(1968,  2, 39126.0, 4.2131700, 0.0025920)]
+     Driftsecond(1968,  2, 39126.0, 4.2131700, 0.0025920))
 
 # Dates and Δ(AT)s.
 const LEAPSECOND =
-    [Leapsecond(1972,  1, 10.0),
+    (Leapsecond(1972,  1, 10.0),
      Leapsecond(1972,  7, 11.0),
      Leapsecond(1973,  1, 12.0),
      Leapsecond(1974,  1, 13.0),
@@ -107,7 +107,7 @@ const LEAPSECOND =
      Leapsecond(2009,  1, 34.0),
      Leapsecond(2012,  7, 35.0),
      Leapsecond(2015,  7, 36.0),
-     Leapsecond(2017,  1, 37.0)]
+     Leapsecond(2017,  1, 37.0))
 
 include("constants.jl")
 include("util.jl")


### PR DESCRIPTION
The structs `Driftsecond` and `Leapsecond` had abstract types in their fields (`Integer` is an abstract type) and this has a huge impact on performance. This PR replaces the abstract types `Integer` with a concrete type `Int`.

Furthermore, the `const LEAPSECOND` and `const DRIFTSECOND` are now tuples instead of vectors, which allows even more compile time optimisations.

Btw. there are a couple more optimisation possibilities which I'll take care in follow-up PRs.

# Before:

```julia
julia> using Astrometry, BenchmarkTools

julia> @benchmark Astrometry.SOFA.dat(2001, 01, 02, 0.0)
BenchmarkTools.Trial: 10000 samples with 203 evaluations per sample.
 Range (min … max):  389.571 ns …  47.125 μs  ┊ GC (min … max): 0.00% … 98.77%
 Time  (median):     415.433 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   467.262 ns ± 830.504 ns  ┊ GC (mean ± σ):  9.12% ±  6.63%

    █▅  ▁▃▁                                                      
  ▄███▆▆███▆▆▅▅▅▄▄▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂ ▃
  390 ns           Histogram: frequency by time          605 ns <

 Memory estimate: 1.05 KiB, allocs estimate: 21.

julia> @benchmark Astrometry.SOFA.dtf2d("UTC", 2000, 1, 1, 12, 0, 0.0)
BenchmarkTools.Trial: 10000 samples with 10 evaluations per sample.
 Range (min … max):  1.462 μs …  1.029 ms  ┊ GC (min … max): 0.00% … 99.47%
 Time  (median):     1.637 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.834 μs ± 11.350 μs  ┊ GC (mean ± σ):  8.19% ±  1.40%

   ▃█▂▂▅█  ▁▅█▃  ▄▄                                           
  ▃███████▆████▇▆███▄▅▄▃▄▃▂▂▂▃▄▃▃▃▃▄▃▃▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  1.46 μs        Histogram: frequency by time        2.36 μs <

 Memory estimate: 3.55 KiB, allocs estimate: 85.
```

# after:

```julia
julia> using Astrometry, BenchmarkTools

julia> @benchmark Astrometry.SOFA.dat(2001, 01, 02, 0.0)
BenchmarkTools.Trial: 10000 samples with 999 evaluations per sample.
 Range (min … max):  12.763 ns … 29.321 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     13.096 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   13.050 ns ±  0.342 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

      █ █         ▂ ▇ ▃
  ▂▁▄▁█▁█▁▅▁▃▁▂▁▃▁█▁█▁█▁▅▁▃▁▂▁▂▁▂▁▂▁▂▁▂▁▂▁▂▁▂▁▂▁▂▁▂▁▂▁▂▁▂▁▂▁▂ ▃
  12.8 ns         Histogram: frequency by time          14 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark Astrometry.SOFA.dtf2d("UTC", 2000, 1, 1, 12, 0, 0.0)
BenchmarkTools.Trial: 10000 samples with 737 evaluations per sample.
 Range (min … max):  171.754 ns …   5.381 μs  ┊ GC (min … max): 0.00% … 95.69%
 Time  (median):     177.294 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   192.877 ns ± 132.700 ns  ┊ GC (mean ± σ):  7.14% ±  9.40%

  █▅▁                                                           ▁
  ███▇▅▄▁▁▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▄▄▅▄▁▄▄▄▄ █
  172 ns        Histogram: log(frequency) by time        981 ns <

 Memory estimate: 352 bytes, allocs estimate: 17.
```

