### PR TITLE
Precompute nutation and equinox matrices for better performance

### DIFF
--- a/src/SOFA/constants.jl
+++ b/src/SOFA/constants.jl
@@ -10,28 +10,6 @@ const lr_1998_a  = SMatrix{60, 2}(vcat([l.a' for l in lr_1998]...)...)
 const b_1998_n   = SMatrix{60, 4}(vcat([b.n' for b in b_1998]...)...)
 const b_1998_a   = SMatrix{60, 1}(vcat([b.a' for b in b_1998]...)...)
 
-#  2000A constants
-const ϕ0_2000_equinox = SMatrix{33, 8}(vcat([t.n' for t in iau_2000_equinox_0_series]...)...)
-const a0_2000_equinox = SMatrix{33, 8}(vcat([t.a' for t in iau_2000_equinox_0_series]...)...)
-const ϕ1_2000_equinox = SMatrix{ 1, 8}(vcat([t.n' for t in iau_2000_equinox_1_series]...)...)
-const a1_2000_equinox = SMatrix{ 1, 8}(vcat([t.a' for t in iau_2000_equinox_1_series]...)...)
-
-const ln_2000A_nutation = SMatrix{678, 5}(vcat([t.n' for t in iau_2000A_nutation_lunisolar_series]...)...)
-const la_2000A_nutation = SMatrix{678, 6}(vcat([t.a' for t in iau_2000A_nutation_lunisolar_series]...)...)
-const pn_2000A_nutation = SMatrix{687,13}(vcat([t.n' for t in iau_2000A_nutation_planetary_series]...)...)
-const pa_2000A_nutation = SMatrix{687, 4}(vcat([t.a' for t in iau_2000A_nutation_planetary_series]...)...)
-
-const ϕ0_2000As = SMatrix{33, 8}(vcat([t.n' for t in s0_2000A]...)...)
-const a0_2000As = SMatrix{33, 2}(vcat([t.a' for t in s0_2000A]...)...)
-const ϕ1_2000As = SMatrix{ 3, 8}(vcat([t.n' for t in s1_2000A]...)...)
-const a1_2000As = SMatrix{ 3, 2}(vcat([t.a' for t in s1_2000A]...)...)
-const ϕ2_2000As = SMatrix{25, 8}(vcat([t.n' for t in s2_2000A]...)...)
-const a2_2000As = SMatrix{25, 2}(vcat([t.a' for t in s2_2000A]...)...)
-const ϕ3_2000As = SMatrix{ 4, 8}(vcat([t.n' for t in s3_2000A]...)...)
-const a3_2000As = SMatrix{ 4, 2}(vcat([t.a' for t in s3_2000A]...)...)
-const ϕ4_2000As = SMatrix{ 1, 8}(vcat([t.n' for t in s4_2000A]...)...)
-const a4_2000As = SMatrix{ 1, 2}(vcat([t.a' for t in s4_2000A]...)...)
-
 #  2000B constants
 const ln_2000B = SMatrix{77, 5}(vcat([t.n' for t in iau_2000B_nutation_lunisolar_series]...)...)
 const la_2000B = SMatrix{77, 6}(vcat([t.a' for t in iau_2000B_nutation_lunisolar_series]...)...)

--- a/src/SOFA/constants.jl
+++ b/src/SOFA/constants.jl
@@ -5,27 +5,7 @@ const PXMIN = 1e-7
 const VMAX  = 0.5
 const IMAX  = 100
 
-const lr_1998_n  = SMatrix{60, 4}(vcat([l.n' for l in lr_1998]...)...)
-const lr_1998_a  = SMatrix{60, 2}(vcat([l.a' for l in lr_1998]...)...)
-const b_1998_n   = SMatrix{60, 4}(vcat([b.n' for b in b_1998]...)...)
-const b_1998_a   = SMatrix{60, 1}(vcat([b.a' for b in b_1998]...)...)
-
-#  2000B constants
-const ln_2000B = SMatrix{77, 5}(vcat([t.n' for t in iau_2000B_nutation_lunisolar_series]...)...)
-const la_2000B = SMatrix{77, 6}(vcat([t.a' for t in iau_2000B_nutation_lunisolar_series]...)...)
-
 #  2006 constants
 const jaxy_2006 = SVector(0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1) .+ 1
 const jasc_2006 = SVector(0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0) .+ 1
 const japt_2006 = SVector(0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4)
-
-const ϕ0_2006s = SMatrix{33, 8}(vcat([t.n' for t in iau_2006_equinox_0_series]...)...)
-const a0_2006s = SMatrix{33, 2}(vcat([t.a' for t in iau_2006_equinox_0_series]...)...)
-const ϕ1_2006s = SMatrix{ 3, 8}(vcat([t.n' for t in iau_2006_equinox_1_series]...)...)
-const a1_2006s = SMatrix{ 3, 2}(vcat([t.a' for t in iau_2006_equinox_1_series]...)...)
-const ϕ2_2006s = SMatrix{25, 8}(vcat([t.n' for t in iau_2006_equinox_2_series]...)...)
-const a2_2006s = SMatrix{25, 2}(vcat([t.a' for t in iau_2006_equinox_2_series]...)...)
-const ϕ3_2006s = SMatrix{ 4, 8}(vcat([t.n' for t in iau_2006_equinox_3_series]...)...)
-const a3_2006s = SMatrix{ 4, 2}(vcat([t.a' for t in iau_2006_equinox_3_series]...)...)
-const ϕ4_2006s = SMatrix{ 1, 8}(vcat([t.n' for t in iau_2006_equinox_4_series]...)...)
-const a4_2006s = SMatrix{ 1, 2}(vcat([t.a' for t in iau_2006_equinox_4_series]...)...)

--- a/src/SOFA/ephemerides.jl
+++ b/src/SOFA/ephemerides.jl
@@ -227,13 +227,13 @@ function moon98(day1::AbstractFloat, day2::AbstractFloat)
     de = Polynomial(SVector(1., 2.).*efac[2:3]...)(Δt)
 
     #  Arange matrices for vector operations.
-    ln  = vcat([SMatrix{1, length(l.n)}(l.n) for l in lr_1998]...)
-    la  = vcat([SMatrix{1, length(l.a)}(l.a) for l in lr_1998]...)
+    ln  = lr_1998_n
+    la  = lr_1998_a
     lre  = [abs(m) == 2 ? e*e    : (abs(m) == 1 ? e  : 1.) for m in ln[:,2]]
     dlre = [abs(m) == 2 ? 2*e*de : (abs(m) == 1 ? de : 0.) for m in ln[:,2]]
 
-    bn   = vcat([SMatrix{1, length(b.n)}(b.n) for b in b_1998]...)
-    ba   = vcat([SMatrix{1, length(b.a)}(b.a) for b in b_1998]...)
+    bn   = b_1998_n
+    ba   = b_1998_a
     bne  = SVector((abs(m) == 2 ? e*e    : (abs(m) == 1 ? e  : 1.) for m in bn[:,2])...)
     dbne = SVector((abs(m) == 2 ? 2*e*de : (abs(m) == 1 ? de : 0.) for m in bn[:,2])...)
 

--- a/src/SOFA/precession.jl
+++ b/src/SOFA/precession.jl
@@ -1904,10 +1904,6 @@ function nut00a(day1::AbstractFloat, day2::AbstractFloat)
 end
 const FACTOR_MICROARCSEC = 1 / 3.6e10
 const FACTOR_DEG2RAD = deg2rad(1 / 3.6e10)
-const iau_2000A_nutation_lunisolar_series_ln = vcat([t.n' for t in iau_2000A_nutation_lunisolar_series]...)
-const iau_2000A_nutation_lunisolar_series_la = vcat([t.a' for t in iau_2000A_nutation_lunisolar_series]...)
-const iau_2000A_nutation_planetary_series_pn = vcat([t.n' for t in iau_2000A_nutation_planetary_series]...)
-const iau_2000A_nutation_planetary_series_pa = vcat([t.a' for t in iau_2000A_nutation_planetary_series]...)
 
 """
     nut00b(day1::AbstractFloat, day2::AbstractFloat)

--- a/src/SOFA/precession.jl
+++ b/src/SOFA/precession.jl
@@ -1798,6 +1798,8 @@ function nut00a(day1::AbstractFloat, day2::AbstractFloat)
     #   Interval between fundamental data J2000.0 and given date (JC.)
     Δt = ((day1 - JD2000) + day2)/(100*DAYPERYEAR)
 
+    FACTOR_MICROARCSEC = 1 / 3.6e10
+
     ####    Luni-Solar Nutation
     #
     #  Fundamental (Delaunay) arguments
@@ -1902,8 +1904,6 @@ function nut00a(day1::AbstractFloat, day2::AbstractFloat)
 
     (ψ = δψl + δψp, ϵ = δϵl + δϵp)
 end
-const FACTOR_MICROARCSEC = 1 / 3.6e10
-const FACTOR_DEG2RAD = deg2rad(1 / 3.6e10)
 
 """
     nut00b(day1::AbstractFloat, day2::AbstractFloat)

--- a/src/SOFA/precession.jl
+++ b/src/SOFA/precession.jl
@@ -1814,8 +1814,8 @@ function nut00a(day1::AbstractFloat, day2::AbstractFloat)
     ω = Polynomial(Ω_2003A...)(Δt)
 
     #  Summation of luni-solar nutation series.
-    ln = vcat([t.n' for t in iau_2000A_nutation_lunisolar_series]...)
-    la = vcat([t.a' for t in iau_2000A_nutation_lunisolar_series]...)
+    ln = iau_2000A_nutation_lunisolar_series_ln
+    la = iau_2000A_nutation_lunisolar_series_la
     # ln = vcat([SMatrix{1, length(t.n)}(t.n) for t in iau_2000A_nutation_lunisolar_series]...)
     # la = vcat([SMatrix{1, length(t.a)}(t.a) for t in iau_2000A_nutation_lunisolar_series]...)
     ϕl = mod2pi.(ln*deg2rad.(rem.(SVector(l, lp, f, d, ω), ARCSECPER2PI)./3600))
@@ -1854,8 +1854,8 @@ function nut00a(day1::AbstractFloat, day2::AbstractFloat)
     #  General accumulated precession in longitude (IERS 2003).
     fpa = Polynomial(lge_2003...)(Δt)
     
-    pn = vcat([t.n' for t in iau_2000A_nutation_planetary_series]...)
-    pa = vcat([t.a' for t in iau_2000A_nutation_planetary_series]...)
+    pn = iau_2000A_nutation_planetary_series_pn
+    pa = iau_2000A_nutation_planetary_series_pa
     # println("$(size(pn)),  $(size(pa))")
     # pn = vcat([SMatrix{1, length(t.n)}(t.n) for t in iau_2000A_nutation_planetary_series]...)
     # pa = vcat([SMatrix{1, length(t.a)}(t.a) for t in iau_2000A_nutation_planetary_series]...)
@@ -1869,6 +1869,10 @@ function nut00a(day1::AbstractFloat, day2::AbstractFloat)
 
     (ψ = δψl + δψp, ϵ = δϵl + δϵp)
 end
+const iau_2000A_nutation_lunisolar_series_ln = vcat([t.n' for t in iau_2000A_nutation_lunisolar_series]...)
+const iau_2000A_nutation_lunisolar_series_la = vcat([t.a' for t in iau_2000A_nutation_lunisolar_series]...)
+const iau_2000A_nutation_planetary_series_pn = vcat([t.n' for t in iau_2000A_nutation_planetary_series]...)
+const iau_2000A_nutation_planetary_series_pa = vcat([t.a' for t in iau_2000A_nutation_planetary_series]...)
 
 """
     nut00b(day1::AbstractFloat, day2::AbstractFloat)

--- a/src/SOFA/precession.jl
+++ b/src/SOFA/precession.jl
@@ -4047,24 +4047,38 @@ function s06(day1::AbstractFloat, day2::AbstractFloat, x::AbstractFloat, y::Abst
         #  General precession in longitude
         fapa03(Δt))
 
-    ϕ0 = vcat([SMatrix{1, length(t.n)}(t.n) for t in iau_2006_equinox_0_series]...)*ϕ
-    a0 = vcat([SMatrix{1, length(t.a)}(t.a) for t in iau_2006_equinox_0_series]...)
-    ϕ1 = vcat([SMatrix{1, length(t.n)}(t.n) for t in iau_2006_equinox_1_series]...)*ϕ
-    a1 = vcat([SMatrix{1, length(t.a)}(t.a) for t in iau_2006_equinox_1_series]...)
-    ϕ2 = vcat([SMatrix{1, length(t.n)}(t.n) for t in iau_2006_equinox_2_series]...)*ϕ
-    a2 = vcat([SMatrix{1, length(t.a)}(t.a) for t in iau_2006_equinox_2_series]...)
-    ϕ3 = vcat([SMatrix{1, length(t.n)}(t.n) for t in iau_2006_equinox_3_series]...)*ϕ
-    a3 = vcat([SMatrix{1, length(t.a)}(t.a) for t in iau_2006_equinox_3_series]...)
-    ϕ4 = vcat([SMatrix{1, length(t.n)}(t.n) for t in iau_2006_equinox_4_series]...)*ϕ
-    a4 = vcat([SMatrix{1, length(t.a)}(t.a) for t in iau_2006_equinox_4_series]...)
+    # a2_2006_equinox
+    ϕ0 = ϕ0_2006_equinox*ϕ
+    a0 = a0_2006_equinox
+    ϕ1 = ϕ1_2006_equinox*ϕ
+    a1 = a1_2006_equinox
+    ϕ2 = ϕ2_2006_equinox*ϕ
+    a2 = a2_2006_equinox
+    ϕ3 = ϕ3_2006_equinox*ϕ
+    a3 = a3_2006_equinox
+    ϕ4 = ϕ4_2006_equinox*ϕ
+    a4 = a4_2006_equinox
 
-    deg2rad(Polynomial(cio_s_2006 .+ SVector(
-        sum(a0[:,1].*sin.(ϕ0) .+ a0[:,2].*cos.(ϕ0)),
-        sum(a1[:,1].*sin.(ϕ1) .+ a1[:,2].*cos.(ϕ1)),
-        sum(a2[:,1].*sin.(ϕ2) .+ a2[:,2].*cos.(ϕ2)),
-        sum(a3[:,1].*sin.(ϕ3) .+ a3[:,2].*cos.(ϕ3)),
-        sum(a4[:,1].*sin.(ϕ4) .+ a4[:,2].*cos.(ϕ4)),
-        0.)...)(Δt)/3600) - x*y/2.0
+    sum0 = sum1 = sum2 = sum3 = sum4 = zero(eltype(a0))
+
+    @inbounds for i in axes(a0, 1)
+        sum0 += a0[i,1] * sin(ϕ0[i]) + a0[i,2] * cos(ϕ0[i])
+    end
+    @inbounds for i in axes(a1, 1)
+        sum1 += a1[i,1] * sin(ϕ1[i]) + a1[i,2] * cos(ϕ1[i])
+    end
+    @inbounds for i in axes(a2, 1)
+        sum2 += a2[i,1] * sin(ϕ2[i]) + a2[i,2] * cos(ϕ2[i])
+    end
+    @inbounds for i in axes(a3, 1)
+        sum3 += a3[i,1] * sin(ϕ3[i]) + a3[i,2] * cos(ϕ3[i])
+    end
+    @inbounds for i in axes(a4, 1)
+        sum4 += a4[i,1] * sin(ϕ4[i]) + a4[i,2] * cos(ϕ4[i])
+    end
+
+    corrections = SVector(sum0, sum1, sum2, sum3, sum4, 0.0)
+    deg2rad(Polynomial((cio_s_2006 .+ corrections)...)(Δt) / 3600) - x*y/2.0
 end
 
 """

--- a/src/SOFA/precession.jl
+++ b/src/SOFA/precession.jl
@@ -1816,8 +1816,8 @@ function nut00a(day1::AbstractFloat, day2::AbstractFloat)
     ω = Polynomial(Ω_2003A...)(Δt)
 
     #  Summation of luni-solar nutation series.
-    ln = iau_2000A_nutation_lunisolar_series_n
-    la = iau_2000A_nutation_lunisolar_series_a
+    ln = ln_2000A_nutation
+    la = la_2000A_nutation
 
     #  Convert from 0.1 μas to radians
     @inbounds begin
@@ -1873,8 +1873,8 @@ function nut00a(day1::AbstractFloat, day2::AbstractFloat)
     #  General accumulated precession in longitude (IERS 2003).
     fpa = Polynomial(lge_2003...)(Δt)
     
-    pn = iau_2000A_nutation_planetary_series_n
-    pa = iau_2000A_nutation_planetary_series_a
+    pn = pn_2000A_nutation
+    pa = pa_2000A_nutation
 
     planet_args = (l00, f00, d00, ω00, fme, fve, fea, fma, fju, fsa, fur, fne, fpa)
     ϕp = Vector{Float64}(undef, size(pn, 1))
@@ -2034,8 +2034,8 @@ function nut00b(day1::AbstractFloat, day2::AbstractFloat)
     ω = Polynomial(Ω_2000B...)(Δt)
 
     #  Summation of luni-solar nutation series.
-    ln = iau_2000B_nutation_lunisolar_series_n
-    la = iau_2000B_nutation_lunisolar_series_a
+    ln = ln_2000B_nutation
+    la = la_2000B_nutation
 
     @inbounds begin
         arg1 = deg2rad(rem(l, ARCSECPER2PI) / 3600)

--- a/src/SOFA/precession.jl
+++ b/src/SOFA/precession.jl
@@ -3773,24 +3773,37 @@ function s00(day1::AbstractFloat, day2::AbstractFloat, x::AbstractFloat, y::Abst
         #  General precession in longitude
         fapa03(Δt))
 
-    ϕ0 = vcat([SMatrix{1, length(t.n)}(t.n) for t in s0_2000A]...)*ϕ
-    a0 = vcat([SMatrix{1, length(t.a)}(t.a) for t in s0_2000A]...)
-    ϕ1 = vcat([SMatrix{1, length(t.n)}(t.n) for t in s1_2000A]...)*ϕ
-    a1 = vcat([SMatrix{1, length(t.a)}(t.a) for t in s1_2000A]...)
-    ϕ2 = vcat([SMatrix{1, length(t.n)}(t.n) for t in s2_2000A]...)*ϕ
-    a2 = vcat([SMatrix{1, length(t.a)}(t.a) for t in s2_2000A]...)
-    ϕ3 = vcat([SMatrix{1, length(t.n)}(t.n) for t in s3_2000A]...)*ϕ
-    a3 = vcat([SMatrix{1, length(t.a)}(t.a) for t in s3_2000A]...)
-    ϕ4 = vcat([SMatrix{1, length(t.n)}(t.n) for t in s4_2000A]...)*ϕ
-    a4 = vcat([SMatrix{1, length(t.a)}(t.a) for t in s4_2000A]...)
+    ϕ0 = ϕ0_2000As*ϕ
+    a0 = a0_2000As
+    ϕ1 = ϕ1_2000As*ϕ
+    a1 = a1_2000As
+    ϕ2 = ϕ2_2000As*ϕ
+    a2 = a2_2000As
+    ϕ3 = ϕ3_2000As*ϕ
+    a3 = a3_2000As
+    ϕ4 = ϕ4_2000As*ϕ
+    a4 = a4_2000As
 
-    deg2rad(Polynomial(sp_2000A .+ SVector(
-        sum(a0[:,1].*sin.(ϕ0) .+ a0[:,2].*cos.(ϕ0)),
-        sum(a1[:,1].*sin.(ϕ1) .+ a1[:,2].*cos.(ϕ1)),
-        sum(a2[:,1].*sin.(ϕ2) .+ a2[:,2].*cos.(ϕ2)),
-        sum(a3[:,1].*sin.(ϕ3) .+ a3[:,2].*cos.(ϕ3)),
-        sum(a4[:,1].*sin.(ϕ4) .+ a4[:,2].*cos.(ϕ4)),
-        0.)...)(Δt)/3600) - x*y/2.0
+    sum0 = sum1 = sum2 = sum3 = sum4 = zero(eltype(a0))
+
+    @inbounds for i in axes(a0, 1)
+        sum0 += a0[i,1] * sin(ϕ0[i]) + a0[i,2] * cos(ϕ0[i])
+    end
+    @inbounds for i in axes(a1, 1)
+        sum1 += a1[i,1] * sin(ϕ1[i]) + a1[i,2] * cos(ϕ1[i])
+    end
+    @inbounds for i in axes(a2, 1)
+        sum2 += a2[i,1] * sin(ϕ2[i]) + a2[i,2] * cos(ϕ2[i])
+    end
+    @inbounds for i in axes(a3, 1)
+        sum3 += a3[i,1] * sin(ϕ3[i]) + a3[i,2] * cos(ϕ3[i])
+    end
+    @inbounds for i in axes(a4, 1)
+        sum4 += a4[i,1] * sin(ϕ4[i]) + a4[i,2] * cos(ϕ4[i])
+    end
+
+    corrections = SVector(sum0, sum1, sum2, sum3, sum4, 0.0)
+    deg2rad(Polynomial((sp_2000A .+ corrections)...)(Δt) / 3600) - x*y/2.0
 end
 
 """

--- a/src/SOFA/precession.jl
+++ b/src/SOFA/precession.jl
@@ -1882,7 +1882,7 @@ function nut00a(day1::AbstractFloat, day2::AbstractFloat)
     planet_args = (l00, f00, d00, ω00, fme, fve, fea, fma, fju, fsa, fur, fne, fpa)
     ϕp = Vector{Float64}(undef, size(pn, 1))
     @inbounds for i in axes(pn, 1)
-        angle = zero(Float64)
+        angle = zero(eltype(planet_args))
         for j in 1:length(planet_args)
             angle += pn[i,j] * planet_args[j]
         end

--- a/src/SOFA/precession.jl
+++ b/src/SOFA/precession.jl
@@ -1816,10 +1816,8 @@ function nut00a(day1::AbstractFloat, day2::AbstractFloat)
     ω = Polynomial(Ω_2003A...)(Δt)
 
     #  Summation of luni-solar nutation series.
-    ln = iau_2000A_nutation_lunisolar_series_ln
-    la = iau_2000A_nutation_lunisolar_series_la
-    # ln = vcat([SMatrix{1, length(t.n)}(t.n) for t in iau_2000A_nutation_lunisolar_series]...)
-    # la = vcat([SMatrix{1, length(t.a)}(t.a) for t in iau_2000A_nutation_lunisolar_series]...)
+    ln = iau_2000A_nutation_lunisolar_series_n
+    la = iau_2000A_nutation_lunisolar_series_a
 
     #  Convert from 0.1 μas to radians
     @inbounds begin
@@ -1875,11 +1873,8 @@ function nut00a(day1::AbstractFloat, day2::AbstractFloat)
     #  General accumulated precession in longitude (IERS 2003).
     fpa = Polynomial(lge_2003...)(Δt)
     
-    pn = iau_2000A_nutation_planetary_series_pn
-    pa = iau_2000A_nutation_planetary_series_pa
-    # println("$(size(pn)),  $(size(pa))")
-    # pn = vcat([SMatrix{1, length(t.n)}(t.n) for t in iau_2000A_nutation_planetary_series]...)
-    # pa = vcat([SMatrix{1, length(t.a)}(t.a) for t in iau_2000A_nutation_planetary_series]...)
+    pn = iau_2000A_nutation_planetary_series_n
+    pa = iau_2000A_nutation_planetary_series_a
 
     planet_args = (l00, f00, d00, ω00, fme, fve, fea, fma, fju, fsa, fur, fne, fpa)
     ϕp = Vector{Float64}(undef, size(pn, 1))

--- a/src/constants1980.jl
+++ b/src/constants1980.jl
@@ -160,3 +160,6 @@ const iau_1980_nutation_series = [
     PeriodicTerms([ 2,  0,  0,  2,  0], [       1.0,    0.0,      0.0,    0.0]),
     PeriodicTerms([ 0,  0,  2,  4,  2], [      -1.0,    0.0,      0.0,    0.0]),
     PeriodicTerms([ 0,  1,  0,  1,  0], [       1.0,    0.0,      0.0,    0.0])]
+
+@const_smatrix_from_series n_1980_nutation iau_1980_nutation_series n
+@const_smatrix_from_series a_1980_nutation iau_1980_nutation_series a

--- a/src/constants2000.jl
+++ b/src/constants2000.jl
@@ -232,3 +232,8 @@ const b_1998 = [
     PeriodicTerms([1,  0, -1, -1], [-0.000119]),
     PeriodicTerms([4, -1,  0, -1], [ 0.000115]),
     PeriodicTerms([2, -2,  0,  1], [ 0.000107])]
+
+@const_smatrix_from_series lr_1998_n lr_1998 n
+@const_smatrix_from_series lr_1998_a lr_1998 a
+@const_smatrix_from_series  b_1998_n  b_1998 n
+@const_smatrix_from_series  b_1998_a  b_1998 a

--- a/src/constants2000A.jl
+++ b/src/constants2000A.jl
@@ -1696,3 +1696,9 @@ const iau_2000A_nutation_planetary_series = [
     PeriodicTerms([-1, 2, 2, 2, 0,  3, -3,  0, 0, 0, 0, 0, 0], [    7,   0,    0,  -3]),
     PeriodicTerms([ 1, 2, 0, 2, 0,  1, -1,  0, 0, 0, 0, 0, 0], [    3,   0,    0,  -1]),
     PeriodicTerms([ 0, 2, 2, 2, 0,  0,  2,  0,-2, 0, 0, 0, 0], [    3,   0,    0,  -1])]
+
+# Pre-computed nutation matrices
+const iau_2000A_nutation_lunisolar_series_ln = vcat([t.n' for t in iau_2000A_nutation_lunisolar_series]...)
+const iau_2000A_nutation_lunisolar_series_la = vcat([t.a' for t in iau_2000A_nutation_lunisolar_series]...)
+const iau_2000A_nutation_planetary_series_pn = vcat([t.n' for t in iau_2000A_nutation_planetary_series]...)
+const iau_2000A_nutation_planetary_series_pa = vcat([t.a' for t in iau_2000A_nutation_planetary_series]...)

--- a/src/constants2000A.jl
+++ b/src/constants2000A.jl
@@ -1698,7 +1698,11 @@ const iau_2000A_nutation_planetary_series = [
     PeriodicTerms([ 0, 2, 2, 2, 0,  0,  2,  0,-2, 0, 0, 0, 0], [    3,   0,    0,  -1])]
 
 # Pre-computed nutation matrices
-const iau_2000A_nutation_lunisolar_series_ln = vcat([t.n' for t in iau_2000A_nutation_lunisolar_series]...)
-const iau_2000A_nutation_lunisolar_series_la = vcat([t.a' for t in iau_2000A_nutation_lunisolar_series]...)
-const iau_2000A_nutation_planetary_series_pn = vcat([t.n' for t in iau_2000A_nutation_planetary_series]...)
-const iau_2000A_nutation_planetary_series_pa = vcat([t.a' for t in iau_2000A_nutation_planetary_series]...)
+tmp = reduce(vcat, [t.n' for t in iau_2000A_nutation_lunisolar_series])
+const iau_2000A_nutation_lunisolar_series_n = SMatrix{size(tmp, 1), size(tmp, 2)}(tmp)
+tmp = reduce(vcat, [t.a' for t in iau_2000A_nutation_lunisolar_series])
+const iau_2000A_nutation_lunisolar_series_a = SMatrix{size(tmp, 1), size(tmp, 2)}(tmp)
+tmp = reduce(vcat, [t.n' for t in iau_2000A_nutation_planetary_series])
+const iau_2000A_nutation_planetary_series_n = SMatrix{size(tmp, 1), size(tmp, 2)}(tmp)
+tmp = reduce(vcat, [t.a' for t in iau_2000A_nutation_planetary_series])
+const iau_2000A_nutation_planetary_series_a = SMatrix{size(tmp, 1), size(tmp, 2)}(tmp)

--- a/src/constants2000A.jl
+++ b/src/constants2000A.jl
@@ -141,6 +141,8 @@ const s4_2000A = [
     PeriodicTerms([0,  0,  0,  0,  1,  0,  0,  0], [   -0.26e-6,  -0.01e-6])]
 
 
+# TODO: the following iau_2000* data may need to be moved to constants2000.jl instead
+
 #   Complementary equinox model constants
 #   Table of coefficients of [l, l', F, D, Ω, LVe, LE, pA], [sin, cos]
 const iau_2000_equinox_0_series = [
@@ -184,6 +186,22 @@ const iau_2000_equinox_0_series = [
 
 const iau_2000_equinox_1_series = [
     PeriodicTerms([ 0,  0,  0,  0,  1,  0,  0,  0], [  -0.87e-6,  0.00e-6])]
+
+@const_smatrix_from_series ϕ0_2000_equinox iau_2000_equinox_0_series n
+@const_smatrix_from_series a0_2000_equinox iau_2000_equinox_0_series a
+@const_smatrix_from_series ϕ1_2000_equinox iau_2000_equinox_1_series n
+@const_smatrix_from_series a1_2000_equinox iau_2000_equinox_1_series a
+
+@const_smatrix_from_series ϕ0_2000As s0_2000A n
+@const_smatrix_from_series a0_2000As s0_2000A a
+@const_smatrix_from_series ϕ1_2000As s1_2000A n
+@const_smatrix_from_series a1_2000As s1_2000A a
+@const_smatrix_from_series ϕ2_2000As s2_2000A n
+@const_smatrix_from_series a2_2000As s2_2000A a
+@const_smatrix_from_series ϕ3_2000As s3_2000A n
+@const_smatrix_from_series a3_2000As s3_2000A a
+@const_smatrix_from_series ϕ4_2000As s4_2000A n
+@const_smatrix_from_series a4_2000As s4_2000A a
 
 #   Luni-solar nutation model constants
 #   (see Matthews, Herring, & Buffet 2002)
@@ -1698,11 +1716,7 @@ const iau_2000A_nutation_planetary_series = [
     PeriodicTerms([ 0, 2, 2, 2, 0,  0,  2,  0,-2, 0, 0, 0, 0], [    3,   0,    0,  -1])]
 
 # Pre-computed nutation matrices
-tmp = reduce(vcat, [t.n' for t in iau_2000A_nutation_lunisolar_series])
-const iau_2000A_nutation_lunisolar_series_n = SMatrix{size(tmp, 1), size(tmp, 2)}(tmp)
-tmp = reduce(vcat, [t.a' for t in iau_2000A_nutation_lunisolar_series])
-const iau_2000A_nutation_lunisolar_series_a = SMatrix{size(tmp, 1), size(tmp, 2)}(tmp)
-tmp = reduce(vcat, [t.n' for t in iau_2000A_nutation_planetary_series])
-const iau_2000A_nutation_planetary_series_n = SMatrix{size(tmp, 1), size(tmp, 2)}(tmp)
-tmp = reduce(vcat, [t.a' for t in iau_2000A_nutation_planetary_series])
-const iau_2000A_nutation_planetary_series_a = SMatrix{size(tmp, 1), size(tmp, 2)}(tmp)
+@const_smatrix_from_series ln_2000A_nutation iau_2000A_nutation_lunisolar_series n
+@const_smatrix_from_series la_2000A_nutation iau_2000A_nutation_lunisolar_series a
+@const_smatrix_from_series pn_2000A_nutation iau_2000A_nutation_planetary_series n
+@const_smatrix_from_series pa_2000A_nutation iau_2000A_nutation_planetary_series a

--- a/src/constants2000B.jl
+++ b/src/constants2000B.jl
@@ -103,7 +103,5 @@ const iau_2000B_nutation_lunisolar_series = [
     PeriodicTerms([-1, 0, 0, 0,2],[   1405.0,    0.0,    4.0,   -610.0,   0.0,   2.0]),
     PeriodicTerms([ 1, 1, 2,-2,2],[   1290.0,    0.0,    0.0,   -556.0,   0.0,   0.0])]
 
-tmp = reduce(vcat, [t.n' for t in iau_2000B_nutation_lunisolar_series])
-const iau_2000B_nutation_lunisolar_series_n = SMatrix{size(tmp, 1), size(tmp, 2)}(tmp)
-tmp = reduce(vcat, [t.a' for t in iau_2000B_nutation_lunisolar_series])
-const iau_2000B_nutation_lunisolar_series_a = SMatrix{size(tmp, 1), size(tmp, 2)}(tmp)
+@const_smatrix_from_series ln_2000B_nutation iau_2000B_nutation_lunisolar_series n
+@const_smatrix_from_series la_2000B_nutation iau_2000B_nutation_lunisolar_series a

--- a/src/constants2000B.jl
+++ b/src/constants2000B.jl
@@ -102,3 +102,8 @@ const iau_2000B_nutation_lunisolar_series = [
     PeriodicTerms([-2, 0, 2, 2,2],[   1383.0,    0.0,   -2.0,   -594.0,   0.0,  -2.0]),
     PeriodicTerms([-1, 0, 0, 0,2],[   1405.0,    0.0,    4.0,   -610.0,   0.0,   2.0]),
     PeriodicTerms([ 1, 1, 2,-2,2],[   1290.0,    0.0,    0.0,   -556.0,   0.0,   0.0])]
+
+tmp = reduce(vcat, [t.n' for t in iau_2000B_nutation_lunisolar_series])
+const iau_2000B_nutation_lunisolar_series_n = SMatrix{size(tmp, 1), size(tmp, 2)}(tmp)
+tmp = reduce(vcat, [t.a' for t in iau_2000B_nutation_lunisolar_series])
+const iau_2000B_nutation_lunisolar_series_a = SMatrix{size(tmp, 1), size(tmp, 2)}(tmp)

--- a/src/constants2006F.jl
+++ b/src/constants2006F.jl
@@ -102,3 +102,15 @@ iau_2006_equinox_3_series = [
 iau_2006_equinox_4_series = [
     #  1- 1
     PeriodicTerms([ 0,  0,  0,  0,  1,  0,  0,  0], [   -0.26e-6,  -0.01e-6 ])]
+
+
+@const_smatrix_from_series ϕ0_2006_equinox iau_2006_equinox_0_series n
+@const_smatrix_from_series a0_2006_equinox iau_2006_equinox_0_series a
+@const_smatrix_from_series ϕ1_2006_equinox iau_2006_equinox_1_series n
+@const_smatrix_from_series a1_2006_equinox iau_2006_equinox_1_series a
+@const_smatrix_from_series ϕ2_2006_equinox iau_2006_equinox_2_series n
+@const_smatrix_from_series a2_2006_equinox iau_2006_equinox_2_series a
+@const_smatrix_from_series ϕ3_2006_equinox iau_2006_equinox_3_series n
+@const_smatrix_from_series a3_2006_equinox iau_2006_equinox_3_series a
+@const_smatrix_from_series ϕ4_2006_equinox iau_2006_equinox_4_series n
+@const_smatrix_from_series a4_2006_equinox iau_2006_equinox_4_series a

--- a/src/model1980.jl
+++ b/src/model1980.jl
@@ -36,11 +36,12 @@ function iau_1980_nutation(date::AbstractFloat)
     ln = n_1980_nutation
     la = a_1980_nutation
 
+    l_rem = rem2pi.(l, RoundNearest)
     sum1 = sum2 = zero(eltype(la))
     @inbounds for i in axes(ln, 1)
         angle = zero(eltype(ln))
         for j in axes(ln, 2)
-            angle += ln[i,j] * rem2pi(l[j], RoundNearest)
+            angle += ln[i,j] * l_rem[j]
         end
 
         s = sin(angle)
@@ -49,10 +50,8 @@ function iau_1980_nutation(date::AbstractFloat)
         sum2 += (la[i,3] + la[i,4] * Δt) * c
     end
 
-    # Convert from 0.1 μas to radians
     DEG2RAD_FACTOR = deg2rad(1 / 3.6e7)
-    δψl = sum1 * DEG2RAD_FACTOR
-    δϵl = sum2 * DEG2RAD_FACTOR
+    (sum1 * DEG2RAD_FACTOR, sum2 * DEG2RAD_FACTOR)
 end
 
 """

--- a/src/model1980.jl
+++ b/src/model1980.jl
@@ -34,7 +34,7 @@ function iau_1980_nutation(date::AbstractFloat)
     )
 
     ln = n_1980_nutation
-    ln = a_1980_nutation
+    la = a_1980_nutation
 
     sum1 = sum2 = zero(eltype(la))
     @inbounds for i in axes(ln, 1)

--- a/src/model2000.jl
+++ b/src/model2000.jl
@@ -24,10 +24,10 @@ function iau_2000_equinox_complement(date)
         Polynomial( lve_2003...)(Δt), Polynomial( lea_2003...)(Δt),
         Polynomial( lge_2003...)(Δt)])
     
-    en0 = vcat([t.n' for t in iau_2000_equinox_0_series]...)
-    ea0 = vcat([t.a' for t in iau_2000_equinox_0_series]...)
-    en1 = vcat([t.n' for t in iau_2000_equinox_1_series]...)
-    ea1 = vcat([t.a' for t in iau_2000_equinox_1_series]...)
+    en0 = ϕ0_2000_equinox
+    ea0 = a0_2000_equinox
+    en1 = ϕ1_2000_equinox
+    ea1 = a1_2000_equinox
     deg2rad((sum(ea0[:,1].*sin.(en0*ϕ) .+ ea0[:,2].*cos.(en0*ϕ)) +
              sum(ea1[:,1].*sin.(en1*ϕ) .+ ea1[:,2].*cos.(en1*ϕ))*Δt)/3600)
 end

--- a/src/model2000.jl
+++ b/src/model2000.jl
@@ -129,39 +129,69 @@ function iau_2000a_gst(ut, tt)
 end
 
 function iau_2000a_nutation(date)
-
     Δt = (date - JD2000)/(100*DAYPERYEAR)
-
+    
     ###  Luni-solar Nutation
     
-    # Fundamental (Delauney) arguments
-    ϕ = deg2rad.(rem.(
-        [Polynomial(l0_2003A...)(Δt), Polynomial(l1_2000A...)(Δt),
-         Polynomial( F_2003A...)(Δt), Polynomial( D_2000A...)(Δt),
-         Polynomial( Ω_2003A...)(Δt)], ARCSECPER2PI)/3600)
+    # Fundamental (Delaunay) arguments
+    @inbounds begin
+        arg1 = deg2rad(rem(Polynomial(l0_2003A...)(Δt), ARCSECPER2PI) / 3600)
+        arg2 = deg2rad(rem(Polynomial(l1_2000A...)(Δt), ARCSECPER2PI) / 3600)
+        arg3 = deg2rad(rem(Polynomial(F_2003A...)(Δt), ARCSECPER2PI) / 3600)
+        arg4 = deg2rad(rem(Polynomial(D_2000A...)(Δt), ARCSECPER2PI) / 3600)
+        arg5 = deg2rad(rem(Polynomial(Ω_2003A...)(Δt), ARCSECPER2PI) / 3600)
+    end
+    
+    ln = ln_2000A_nutation
+    la = la_2000A_nutation
+    ψl = ϵl = zero(eltype(la))
+    @inbounds for i in axes(ln, 1)
+        angle = ln[i,1] * arg1 + ln[i,2] * arg2 + ln[i,3] * arg3 + ln[i,4] * arg4 + ln[i,5] * arg5
+        angle = rem2pi(angle, RoundToZero)
 
-    lϕ  = rem2pi.(vcat([t.n' for t in iau_2000A_nutation_lunisolar_series]...)*ϕ, RoundToZero)
-    la  = vcat([t.a' for t in iau_2000A_nutation_lunisolar_series]...)
-    ψl = sum((la[:,1] .+ la[:,2].*Δt).*sin.(lϕ) .+ la[:,3].*cos.(lϕ))
-    ϵl = sum(la[:,6].*sin.(lϕ) .+ (la[:,4] .+ la[:,5].*Δt).*cos.(lϕ))
-
+        s = sin(angle)
+        c = cos(angle)
+        ψl += (la[i,1] + la[i,2] * Δt) * s + la[i,3] * c
+        ϵl += la[i,6] * s + (la[i,4] + la[i,5] * Δt) * c
+    end
+    
     ###  Planetary Nutation
+    
+    planet_args = SVector(
+        rem2pi(Polynomial(l0_2000A_planet...)(Δt), RoundToZero),
+        rem2pi(Polynomial(F_2000A_planet...)(Δt), RoundToZero),
+        rem2pi(Polynomial(D_2000A_planet...)(Δt), RoundToZero),
+        rem2pi(Polynomial(Ω_2000A_planet...)(Δt), RoundToZero),
+        rem2pi(Polynomial(lme_2003...)(Δt), RoundToZero),
+        rem2pi(Polynomial(lve_2003...)(Δt), RoundToZero),
+        rem2pi(Polynomial(lea_2003...)(Δt), RoundToZero),
+        rem2pi(Polynomial(lma_2003...)(Δt), RoundToZero),
+        rem2pi(Polynomial(lju_2003...)(Δt), RoundToZero),
+        rem2pi(Polynomial(lsa_2003...)(Δt), RoundToZero),
+        rem2pi(Polynomial(lur_2003...)(Δt), RoundToZero),
+        rem2pi(Polynomial(lne_2003mhb...)(Δt), RoundToZero),
+        Polynomial(lge_2003...)(Δt)
+    )
+    
+    pn = pn_2000A_nutation
+    pa = pa_2000A_nutation
+    ψp = ϵp = zero(eltype(pa))
+    @inbounds for i in axes(pn, 1)
+        angle = zero(eltype(pn))
+        for j in 1:13
+            angle += pn[i,j] * planet_args[j]
+        end
+        angle = rem2pi(angle, RoundToZero)
 
-    ϕ = rem2pi.([
-        Polynomial(l0_2000A_planet...)(Δt), Polynomial( F_2000A_planet...)(Δt),
-        Polynomial( D_2000A_planet...)(Δt), Polynomial( Ω_2000A_planet...)(Δt),
-        Polynomial(lme_2003...)(Δt), Polynomial(lve_2003...)(Δt),
-        Polynomial(lea_2003...)(Δt), Polynomial(lma_2003...)(Δt),
-        Polynomial(lju_2003...)(Δt), Polynomial(lsa_2003...)(Δt),
-        Polynomial(lur_2003...)(Δt), Polynomial(lne_2003mhb...)(Δt)], RoundToZero)
-    push!(ϕ, Polynomial(lge_2003...)(Δt))
-
-    pϕ = rem2pi.(vcat([t.n' for t in iau_2000A_nutation_planetary_series]...)*ϕ, RoundToZero)
-    pa = vcat([t.a' for t in iau_2000A_nutation_planetary_series]...)
-    ψp = sum(pa[:,1].*sin.(pϕ) .+ pa[:,2].*cos.(pϕ))
-    ϵp = sum(pa[:,3].*sin.(pϕ) .+ pa[:,4].*cos.(pϕ))
-
-    deg2rad.((ψl + ψp, ϵl + ϵp)./3.6e10)
+        s = sin(angle)
+        c = cos(angle)
+        ψp += pa[i,1] * s + pa[i,2] * c
+        ϵp += pa[i,3] * s + pa[i,4] * c
+    end
+    
+    # Convert from 0.1 μas to radians
+    FACTOR = deg2rad(1 / 3.6e10)
+    ((ψl + ψp) * FACTOR, (ϵl + ϵp) * FACTOR)
 end
 
 function iau_2000a_xys(date)

--- a/src/model2006.jl
+++ b/src/model2006.jl
@@ -30,24 +30,37 @@ function iau_2006_cio_locator(date, coord)
         mod2pi(Polynomial(lea_2003...)(Δt)),
         Polynomial(lge_2003...)(Δt))
 
-    ϕ0 = vcat([t.n' for t in iau_2006_equinox_0_series]...)*ϕ
-    a0 = vcat([t.a' for t in iau_2006_equinox_0_series]...)
-    ϕ1 = vcat([t.n' for t in iau_2006_equinox_1_series]...)*ϕ
-    a1 = vcat([t.a' for t in iau_2006_equinox_1_series]...)
-    ϕ2 = vcat([t.n' for t in iau_2006_equinox_2_series]...)*ϕ
-    a2 = vcat([t.a' for t in iau_2006_equinox_2_series]...)
-    ϕ3 = vcat([t.n' for t in iau_2006_equinox_3_series]...)*ϕ
-    a3 = vcat([t.a' for t in iau_2006_equinox_3_series]...)
-    ϕ4 = vcat([t.n' for t in iau_2006_equinox_4_series]...)*ϕ
-    a4 = vcat([t.a' for t in iau_2006_equinox_4_series]...)
+    ϕ0 = ϕ0_2006_equinox*ϕ
+    a0 = a0_2006_equinox
+    ϕ1 = ϕ1_2006_equinox*ϕ
+    a1 = a1_2006_equinox
+    ϕ2 = ϕ2_2006_equinox*ϕ
+    a2 = a2_2006_equinox
+    ϕ3 = ϕ3_2006_equinox*ϕ
+    a3 = a3_2006_equinox
+    ϕ4 = ϕ4_2006_equinox*ϕ
+    a4 = a4_2006_equinox
 
-    deg2rad(Polynomial(cio_s_2006 .+ SVector(
-        sum(a0[:,1].*sin.(ϕ0) .+ a0[:,2].*cos.(ϕ0)),
-        sum(a1[:,1].*sin.(ϕ1) .+ a1[:,2].*cos.(ϕ1)),
-        sum(a2[:,1].*sin.(ϕ2) .+ a2[:,2].*cos.(ϕ2)),
-        sum(a3[:,1].*sin.(ϕ3) .+ a3[:,2].*cos.(ϕ3)),
-        sum(a4[:,1].*sin.(ϕ4) .+ a4[:,2].*cos.(ϕ4)), 0.0)...)(Δt)/3600) -
-            coord[1]*coord[2]/2
+    sum0 = sum1 = sum2 = sum3 = sum4 = zero(eltype(a0))
+
+    @inbounds for i in axes(a0, 1)
+        sum0 += a0[i,1] * sin(ϕ0[i]) + a0[i,2] * cos(ϕ0[i])
+    end
+    @inbounds for i in axes(a1, 1)
+        sum1 += a1[i,1] * sin(ϕ1[i]) + a1[i,2] * cos(ϕ1[i])
+    end
+    @inbounds for i in axes(a2, 1)
+        sum2 += a2[i,1] * sin(ϕ2[i]) + a2[i,2] * cos(ϕ2[i])
+    end
+    @inbounds for i in axes(a3, 1)
+        sum3 += a3[i,1] * sin(ϕ3[i]) + a3[i,2] * cos(ϕ3[i])
+    end
+    @inbounds for i in axes(a4, 1)
+        sum4 += a4[i,1] * sin(ϕ4[i]) + a4[i,2] * cos(ϕ4[i])
+    end
+
+    corrections = SVector(sum0, sum1, sum2, sum3, sum4, 0.0)
+    deg2rad(Polynomial((cio_s_2006 .+ corrections)...)(Δt) / 3600) - coord[1] * coord[2] / 2
 end
 
 function iau_2006_cip_xy(date)

--- a/src/util.jl
+++ b/src/util.jl
@@ -103,3 +103,18 @@ end
 """
 proper_motion(object, pmotion, parallax, rvelocity) =
     proper_motion(object, pmotion, parallax, rvelocity, 0., (0., 0., 0.))
+
+
+"""
+   @const_smatrix_from_series name series field
+
+Defines a global constant SMatrix instances with a agiven `name` from
+a `series` and using its `field` name.
+"""
+macro const_smatrix_from_series(name, series, field)
+    return quote
+        local tmp = reduce(vcat, [getfield(t, $(QuoteNode(field)))' for t in $(esc(series))])
+        const $(esc(name)) = SMatrix{size(tmp)...}(tmp...)
+    end
+end
+


### PR DESCRIPTION
This PR precomputes the planetary and lunisolar nutation matrices so that they are not calculated on each call of e.g. `nut00a` or `nut00b`.

It's a 10x speed-up and the allocations go down from 5600 to 4 in case of `nut00a`. Further improvements have been made to the code as well to achieve this radical allocs-cutoff, also in other functions which use such matrices.

### Before

```julia
julia> using Astrometry.SOFA, Dates

julia> @benchmark nut00a(t, 0.0) setup=t=datetime2unix(now())
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  231.125 μs …   6.252 ms  ┊ GC (min … max): 0.00% … 94.10%
 Time  (median):     250.875 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   273.128 μs ± 141.337 μs  ┊ GC (mean ± σ):  5.41% ±  9.46%

  ▇█▆▅▄▃▃▂▁                                                     ▂
  ███████████▇▇▆▆▄▅▄▃▁▁▄▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁▁▁▄▄▅▄▆▄▄▃▃▃▁▁▃▃▁▄▄▅▆▅▆▆ █
  231 μs        Histogram: log(frequency) by time       1.01 ms <

 Memory estimate: 319.53 KiB, allocs estimate: 5601.
```

### After

```julia
julia> using Astrometry.SOFA, Dates

julia> @benchmark nut00a(t, 0.0) setup=t=datetime2unix(now())
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  23.167 μs …  6.235 ms  ┊ GC (min … max): 0.00% … 99.01%
 Time  (median):     24.584 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   25.358 μs ± 62.122 μs  ┊ GC (mean ± σ):  2.43% ±  0.99%

      ▁     ▄▇█▇▃
  ▁▄▆▇████▇██████▇▅▄▄▂▃▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  23.2 μs         Histogram: frequency by time        30.4 μs <

 Memory estimate: 11.06 KiB, allocs estimate: 4.
```

The main motivation is the calculation of local to equatorial coordinates where this function is called and responsible for about 80% of the computing time (and 99% of the allocations 😉 )