### PR TITLE
fixed bug in tf2a, tf2d and updated tests

### DIFF
--- a/src/SOFA/vectorops.jl
+++ b/src/SOFA/vectorops.jl
@@ -268,7 +268,7 @@ function tf2a(sign::Char, hour::Integer, minute::Integer, second::Real)
     @assert 0   <= minute <   60  "minute out of range [0-59]."
     @assert 0.0 <= second < 60.0 "second out of range [0-60]."
     
-    15*deg2rad(1/3600) * (sign == '-' > -1.0 : 1.0) *
+    15*deg2rad(1/3600) * (sign == '-' ? -1.0 : 1.0) *
         (60.0 * (60.0 * abs(hour) + abs(minute)) + abs(second))
 end
 
@@ -303,7 +303,7 @@ function tf2d(sign::Char, hour::Integer, minute::Integer, second::Real)
     @assert 0   <= minute <   60  "minute out of range [0-59]."
     @assert 0.0 <= second < 60.0 "second out of range [0-60]."
     
-    (sign == '-' > -1.0 : 1.0) *
+    (sign == '-' ? -1.0 : 1.0) *
         (60.0 * (60.0 * abs(hour) + abs(minute)) + abs(second)) / SECPERDAY
 end
 

--- a/test/sofatests.jl
+++ b/test/sofatests.jl
@@ -1357,11 +1357,10 @@
 @test SOFA.dat(2017, 9, 1, 0.0) == 37.0
 
 #   Approximation to TDB-TT
-@test (SOFA.dtdb(2448939.5, 0.123, 0.76543, 5.0123, 5525.242, 3190.0) -
-       -0.1280368005936998991e-2) <= 1e-15
+@test SOFA.dtdb(2448939.5, 0.123, 0.76543, 5.0123, 5525.242, 3190.0) ≈ -0.1280368005936998991e-2 atol=1e-15
 
 #   Universal Coordinated Time (UTC) to Julian day, including leap second
-@test (sum(values(SOFA.dtf2d("UTC", 1994, 6, 30, 23, 59, 60.13599))) - 2449534.49999) <= 1e-13
+@test sum(values(SOFA.dtf2d("UTC", 1994, 6, 30, 23, 59, 60.13599))) ≈ 2449534.49999 atol=1e-13
 
 @test all(abs.(values(SOFA.taitt(2453750.5, 0.892482639)) .- (2453750.5, 0.892855139)) .<= 1e-12)
 
@@ -1449,17 +1448,17 @@
 
 @test all(values(SOFA.a2tf(4, -3.01234)) .== ('-', 11, 30, 22, 6484))
 
-@test (SOFA.af2a('-', 45, 13, 27.2) - -0.7893115794313644842) <= 1e-12
+@test SOFA.af2a('-', 45, 13, 27.2) ≈ -0.7893115794313644842 atol=1e-12
 
-@test (SOFA.anp(-0.1) - 6.183185307179586477) <= 1e-12
+@test SOFA.anp(-0.1) ≈ 6.183185307179586477 atol=1e-12
 
-@test (SOFA.anpm(-4.0) - 2.283185307179586477) <= 1e-12
+@test SOFA.anpm(-4.0) ≈ 2.283185307179586477 atol=1e-12
 
 @test all(values(SOFA.d2tf(4, -0.987654321)) .== ('-', 23, 42, 13, 3333))
 
-@test (SOFA.tf2a('+', 4, 58, 20.2) - 1.301739278189537429) <= 1e-12
+@test SOFA.tf2a('+', 4, 58, 20.2) ≈ 1.301739278189537429 atol=1e-12
 
-@test (SOFA.tf2d(' ', 23, 55, 10.9) - 0.9966539351851851852) <= 1e-12
+@test SOFA.tf2d(' ', 23, 55, 10.9) ≈ 0.9966539351851851852 atol=1e-12
 
 ####    Test Vector-Matrix Build Rotations    ####
 


### PR DESCRIPTION
When trying to use the `tf2a` function is realized that is always returned 0.0. 
```julia
julia> SOFA.tf2a('+', 4, 58, 20.2)
0.0
```
Nonetheless, all the test passed.

I rewrote all tests, where the `abs` function was missing and saw two functions now failing. 
`tf2a` and `tf2d` are now both fixed.