### PR TITLE
Precalculate e-masks for moon98

### DIFF
--- a/src/SOFA/ephemerides.jl
+++ b/src/SOFA/ephemerides.jl
@@ -227,15 +227,15 @@ function moon98(day1::AbstractFloat, day2::AbstractFloat)
     de = Polynomial(SVector(1., 2.).*efac[2:3]...)(Δt)
 
     #  Arange matrices for vector operations.
+    lre  = map(m -> m == 2 ? e*e    : (m == 1 ? e  : 1.0), lr_emask)
+    dlre = map(m -> m == 2 ? 2*e*de : (m == 1 ? de : 0.0), lr_emask)
+    bne  = map(m -> m == 2 ? e*e    : (m == 1 ? e  : 1.0), b_emask)
+    dbne = map(m -> m == 2 ? 2*e*de : (m == 1 ? de : 0.0), b_emask)
+
     ln  = lr_1998_n
     la  = lr_1998_a
-    lre  = [abs(m) == 2 ? e*e    : (abs(m) == 1 ? e  : 1.) for m in ln[:,2]]
-    dlre = [abs(m) == 2 ? 2*e*de : (abs(m) == 1 ? de : 0.) for m in ln[:,2]]
-
     bn   = b_1998_n
     ba   = b_1998_a
-    bne  = SVector((abs(m) == 2 ? e*e    : (abs(m) == 1 ? e  : 1.) for m in bn[:,2])...)
-    dbne = SVector((abs(m) == 2 ? 2*e*de : (abs(m) == 1 ? de : 0.) for m in bn[:,2])...)
 
     ϕ, dϕ = ln*SVector(dm, ls, lm, fm), ln*SVector(ddm, dls, dlm, dfm)
     ψ, dψ = SVector(a1, λm-fm, a2), SVector(da1, dλm-dfm, da2)

--- a/src/constants2000.jl
+++ b/src/constants2000.jl
@@ -237,3 +237,12 @@ const b_1998 = [
 @const_smatrix_from_series lr_1998_a lr_1998 a
 @const_smatrix_from_series  b_1998_n  b_1998 n
 @const_smatrix_from_series  b_1998_a  b_1998 a
+
+# The e-factor (e) is a small correction term that accounts for the eccentricity
+# of Earth's orbit around the Sun. Its influence on the Moon's position depends
+# on whether the Sun's mean annomaly (ls, the second column of the n-matrices)
+# appears in each term of the summation.
+# Teh following emasks encode which of those three cases applies to each of the rows.
+# These masks are mainly used in the moon98 routine to dramatically reduce allocations.
+const lr_emask = map(m -> abs(m) == 2 ? 2 : (abs(m) == 1 ? 1 : 0), lr_1998_n[:, 2])
+const b_emask = map(m -> abs(m) == 2 ? 2 : (abs(m) == 1 ? 1 : 0), b_1998_n[:, 2])


### PR DESCRIPTION
This PR simply precalculates the "e-masks" so that they are not recalculated at every call of `moon98`.

The speed up is factor 10+ and the allocations go from 400 to 8:

Before:

```julia
julia> @benchmark SOFA.moon98(jdtt...)
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  42.833 μs …  20.764 ms  ┊ GC (min … max): 0.00% … 99.51%
 Time  (median):     46.042 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   51.179 μs ± 247.696 μs  ┊ GC (mean ± σ):  6.68% ±  1.41%

      ▁▃██▃▃▁
  ▁▂▄▆████████▅▄▃▃▃▄▃▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▂▂▁▂▂▂▂▂▁▂▂▁▁▁▁▁▁▁▁▁▁ ▂
  42.8 μs         Histogram: frequency by time         64.4 μs <

 Memory estimate: 40.45 KiB, allocs estimate: 411.
```

After
```julia
julia> @benchmark SOFA.moon98(jdtt...)
BenchmarkTools.Trial: 10000 samples with 8 evaluations per sample.
 Range (min … max):  3.062 μs …  5.089 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.089 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.102 μs ± 42.261 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

       ▆ █ ▆ ▃ ▁
  ▂▂▁▆▁█▁█▁█▁█▁█▁▇▁▅▁▄▁▃▁▃▁▃▁▃▃▁▃▁▃▁▃▁▃▁▃▁▃▁▃▁▃▁▃▁▃▁▃▁▂▁▂▁▂▂ ▃
  3.06 μs        Histogram: frequency by time        3.22 μs <

 Memory estimate: 224 bytes, allocs estimate: 8.
```